### PR TITLE
feat: expose generic Culligan IoT datapoint sensors

### DIFF
--- a/custom_components/culligan/__init__.py
+++ b/custom_components/culligan/__init__.py
@@ -14,7 +14,7 @@ import asyncio
 import async_timeout
 
 from ayla_iot_unofficial.device import Softener
-from culligan.culliganiot_device import CulliganIoTSoftener
+from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
 
 from contextlib import suppress
 
@@ -130,8 +130,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     else:
         LOGGER.debug("Bad logic in devices selection")
 
-    # separate devices from supported devices since processing unsupported devices results in too many errors
-    SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener]
+    # separate devices from supported devices since processing unsupported devices results in too many errors.
+    # Generic CulliganIoTDevice support is read-only and lets non-softener devices, such as Smart RO,
+    # surface their cloud datapoints without requiring device-specific commands or property mappings.
+    SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener, CulliganIoTDevice]
     supported_devices = []
     for device in all_devices:
         if type(device) in SUPPORTED_DEVICE_CLASSES:

--- a/custom_components/culligan/entity.py
+++ b/custom_components/culligan/entity.py
@@ -22,19 +22,21 @@ class CulliganBaseEntity(CoordinatorEntity, Entity):
         # at a high level, we want to know if it's a culligan 'thing' or an ayla 'thing'
         self._io_culligan    = isinstance(device, CulliganIoTDevice)
 
-        # if culligan iot, but not classified as 'softener' ... expect things to break
+        # Generic CulliganIoTDevice entities are supported as read-only datapoint sensors.
+        # Device-specific controls still belong on explicit subclasses such as CulliganIoTSoftener.
         if self._io_culligan and not isinstance(device, CulliganIoTSoftener):
-            LOGGER.warning(f"Device {device.device_serial_number} is a CulliganIoT device, but was not cast as a CulliganIoTSoftener. Expect things to break!")
+            LOGGER.debug("Device %s is a generic CulliganIoT device", device.device_serial_number)
         
         # Similar, if Ayla, but not classified as 'softener' ... expect things to break
         if not self._io_culligan and not isinstance(device, Softener):
             LOGGER.warning(f"Device {device.device_serial_number} is an Ayla device, but was not cast as a Softener. Expect things to break!")
 
         # self.base_unique_id = device.name + "_" + device.device_serial_number
+        model = getattr(self.device, "device_model_number", None) or getattr(self.device, "_model", None)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.device.device_serial_number)},
             manufacturer="Culligan",
-            model=f"{self.device.name + ' ' + self.device.device_model_number}",
+            model=" ".join(part for part in [self.device.name, model] if part),
             name=self.device.name
         )
 

--- a/custom_components/culligan/sensor.py
+++ b/custom_components/culligan/sensor.py
@@ -7,7 +7,8 @@ from .update_coordinator import CulliganUpdateCoordinator
 
 from ayla_iot_unofficial.device import Device
 from collections.abc import Iterable
-from culligan.culliganiot_device import CulliganIoTDevice
+from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
+import re
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
@@ -22,6 +23,16 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import generate_entity_id
+
+
+def _slugify_datapoint_id(datapoint_id: str) -> str:
+    """Normalize a cloud datapoint name for HA unique IDs/entity IDs."""
+    return re.sub(r"_+", "_", re.sub(r"[^a-zA-Z0-9_]+", "_", datapoint_id)).strip("_").lower()
+
+
+def _describe_datapoint(datapoint_id: str) -> str:
+    """Turn a raw cloud datapoint name into a readable sensor name."""
+    return datapoint_id.replace("_", " ")
 
 
 async def async_setup_entry(
@@ -283,6 +294,26 @@ async def async_setup_entry(
     for device in devices:
         LOGGER.debug("Working on adding sensors device: %s", device._device_serial_number)
         sensors = []
+
+        # Non-softener CulliganIoT devices, such as Smart RO, do not have a known property map yet.
+        # Expose their returned datapoints read-only so users can discover what the API provides.
+        if isinstance(device, CulliganIoTDevice) and not isinstance(device, CulliganIoTSoftener):
+            for datapoint_id in sorted(device.properties.keys()):
+                LOGGER.debug("generic CulliganIoT sensor calling async_add: %s", datapoint_id)
+                sensors += [
+                    GenericCulliganIoTSensor(
+                        coordinator,
+                        device,
+                        datapoint_id,
+                    )
+                ]
+
+            if len(sensors) > 0:
+                async_add_devices(sensors)
+
+            LOGGER.debug("Finished generic CulliganIoT sensor async_add_devices")
+            continue
+
         for sensor in softener_sensors:
             LOGGER.debug("sensor calling async_add: %s", sensor[0])
             sensors += [
@@ -304,6 +335,49 @@ async def async_setup_entry(
             async_add_devices(sensors)
 
         LOGGER.debug("Finished sensor async_add_devices")
+
+
+class GenericCulliganIoTSensor(CulliganBaseEntity, SensorEntity):
+    """Read-only sensor for generic CulliganIoT device datapoints."""
+
+    has_entity_name = True
+    use_device_name = False
+
+    def __init__(
+        self,
+        coordinator: CulliganUpdateCoordinator,
+        device: CulliganIoTDevice,
+        datapoint_id: str,
+    ) -> None:
+        """Initialize the generic CulliganIoT datapoint sensor."""
+        super().__init__(coordinator, device)
+
+        self._attr_sensor_id = datapoint_id
+        self._attr_description = _describe_datapoint(datapoint_id)
+        self._attr_icon = "mdi:water-circle"
+        slug = _slugify_datapoint_id(datapoint_id)
+        self._attr_unique_id = f"{device.device_serial_number}_{slug}"
+        self.entity_id = generate_entity_id("sensor.{}", self._attr_unique_id, None, coordinator.hass)
+
+    @property
+    def native_value(self):
+        """Return the raw datapoint value."""
+        return self.device.get_property_value(self._attr_sensor_id)
+
+    @property
+    def name(self) -> str | None:
+        """Define name as description. This shows in the Sensor Name column of entities."""
+        return self._attr_description
+
+    @property
+    def unique_id(self) -> str | None:
+        """Suggest the unique id of the entity. User never sees these."""
+        return self._attr_unique_id
+
+    @property
+    def icon(self) -> str | None:
+        """Define the icon."""
+        return self._attr_icon
 
 
 #class SoftenerSensor(CulliganWaterSoftenerEntity):

--- a/custom_components/culligan/update_coordinator.py
+++ b/custom_components/culligan/update_coordinator.py
@@ -68,7 +68,7 @@ class CulliganUpdateCoordinator(DataUpdateCoordinator[bool]):
         return dsn in self._online_dsns
 
     @staticmethod
-    async def _async_update_softener(softener: Softener | CulliganIoTSoftener) -> None:
+    async def _async_update_softener(softener: Softener | CulliganIoTDevice | CulliganIoTSoftener) -> None:
         """Asynchronously update the data for a single device."""
         dsn = softener.device_serial_number
         LOGGER.debug(
@@ -103,8 +103,8 @@ class CulliganUpdateCoordinator(DataUpdateCoordinator[bool]):
                     "batch_datapoint send failure, properties will not be accurate"
                 )
 
-        if isinstance(softener, CulliganIoTSoftener):
-            LOGGER.debug("updating culliganiot softener")
+        if isinstance(softener, CulliganIoTDevice):
+            LOGGER.debug("updating culliganiot device")
             async with timeout(API_TIMEOUT):
                 try:
                     LOGGER.debug("starting async_update")
@@ -192,7 +192,7 @@ class CulliganUpdateCoordinator(DataUpdateCoordinator[bool]):
 
         # self.culligan_devices is now only supported_devices as of 1.3.1, need another check here to not update 'online but not supported' devices
         temp = {}
-        SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener]
+        SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener, CulliganIoTDevice]
         for device in all_online_devices:
             dsn = ""
             # check DSN for Ayla, serialNumber for CulliganIoT


### PR DESCRIPTION
## Summary
- Stops dropping generic CulliganIoT devices during setup/update.
- Adds read-only generic datapoint sensors for non-softener CulliganIoT devices, intended as a first discovery path for Smart RO devices.
- Keeps existing softener-specific sensors and controls unchanged.

## Why
Accounts can include non-softener CulliganIoT devices such as Smart RO systems. The current integration discovers them through the Culligan account but filters them out before Home Assistant can expose anything. The underlying `culligan` library already supports fetching generic device datapoints through `/device/data?serialNumber=...`.

## Notes
This is intentionally a diagnostic/discovery-first change. It does not add RO controls and does not try to guess polished device classes or units before seeing real Smart RO datapoints.

## Test plan
- [x] `python3 -m compileall -q custom_components/culligan`
- [ ] Test against an account with a Smart RO device and inspect generated datapoint sensors.
- [ ] Promote known RO datapoints to typed sensors once payloads are confirmed.
