### PR TITLE
feat: expose Smart RO datapoint sensors

### DIFF
--- a/custom_components/culligan/__init__.py
+++ b/custom_components/culligan/__init__.py
@@ -14,7 +14,7 @@ import asyncio
 import async_timeout
 
 from ayla_iot_unofficial.device import Softener
-from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
+from culligan.culliganiot_device import CulliganIoTRO, CulliganIoTSoftener
 
 from contextlib import suppress
 
@@ -131,9 +131,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         LOGGER.debug("Bad logic in devices selection")
 
     # separate devices from supported devices since processing unsupported devices results in too many errors.
-    # Generic CulliganIoTDevice support is read-only and lets non-softener devices, such as Smart RO,
-    # surface their cloud datapoints without requiring device-specific commands or property mappings.
-    SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener, CulliganIoTDevice]
+    # CulliganIoTRO support is read-only and surfaces Smart RO cloud datapoints
+    # without enabling unknown device commands.
+    SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener, CulliganIoTRO]
     supported_devices = []
     for device in all_devices:
         if type(device) in SUPPORTED_DEVICE_CLASSES:

--- a/custom_components/culligan/__init__.py
+++ b/custom_components/culligan/__init__.py
@@ -14,7 +14,7 @@ import asyncio
 import async_timeout
 
 from ayla_iot_unofficial.device import Softener
-from culligan.culliganiot_device import CulliganIoTSoftener
+from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
 
 from contextlib import suppress
 
@@ -130,8 +130,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     else:
         LOGGER.debug("Bad logic in devices selection")
 
-    # separate devices from supported devices since processing unsupported devices results in too many errors
-    SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener]
+    # separate devices from supported devices since processing unsupported devices results in too many errors.
+    # Generic CulliganIoTDevice support is read-only and lets non-softener devices, such as Smart RO,
+    # surface their cloud datapoints without requiring device-specific commands or property mappings.
+    SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener, CulliganIoTDevice]
     supported_devices = []
     for device in all_devices:
         if type(device) in SUPPORTED_DEVICE_CLASSES:

--- a/custom_components/culligan/binary_sensor.py
+++ b/custom_components/culligan/binary_sensor.py
@@ -4,7 +4,7 @@ from .entity import CulliganBaseEntity
 from .update_coordinator import CulliganUpdateCoordinator
 from ayla_iot_unofficial.device import Device
 from collections.abc import Iterable
-from culligan.culliganiot_device import CulliganIoTDevice
+from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.core import HomeAssistant
@@ -75,6 +75,13 @@ async def async_setup_entry(
     # Method two ... create individual sensors from a map of defined sensor attributes
     for device in devices:
         LOGGER.debug("Working on device: %s", device._device_serial_number)
+
+        # Generic CulliganIoT devices are exposed read-only from sensor.py only.
+        # Do not create softener-specific binary sensors for devices such as Smart RO.
+        if isinstance(device, CulliganIoTDevice) and not isinstance(device, CulliganIoTSoftener):
+            LOGGER.debug("Skipping softener binary sensors for generic CulliganIoT device: %s", device._device_serial_number)
+            continue
+
         binary_sensors = []
         for sensor in binary_sensor_config:
             LOGGER.debug("binary sensor calling async_add: %s", sensor[0])

--- a/custom_components/culligan/button.py
+++ b/custom_components/culligan/button.py
@@ -20,8 +20,8 @@ from ayla_iot_unofficial.device import Device, Softener
 from collections.abc import Iterable
 from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
 
-AYLA_DEVICES = [Device, Softener]
-CULLIGAN_IOT_DEVICES = [CulliganIoTDevice, CulliganIoTSoftener]
+AYLA_DEVICES = [Softener]
+CULLIGAN_IOT_DEVICES = [CulliganIoTSoftener]
 ALL_DEVICES = AYLA_DEVICES + CULLIGAN_IOT_DEVICES
 
 async def async_setup_entry(

--- a/custom_components/culligan/button.py
+++ b/custom_components/culligan/button.py
@@ -8,11 +8,19 @@ import voluptuous as vol
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 # from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import generate_entity_id
 
-from .const import DOMAIN, LOGGER, PROPERTY_VALUE_MAP
+from .const import (
+    DEFAULT_TIMED_BYPASS_MINUTES,
+    DOMAIN,
+    LOGGER,
+    MAX_TIMED_BYPASS_MINUTES,
+    MIN_TIMED_BYPASS_MINUTES,
+    PROPERTY_VALUE_MAP,
+)
 from .entity import CulliganBaseEntity
 from .update_coordinator import CulliganUpdateCoordinator
 
@@ -43,6 +51,11 @@ async def async_setup_entry(
             "clear bypass",
             "mdi:valve-open",
             ALL_DEVICES,
+        ),
+        (
+            "start timed bypass",
+            "mdi:timer-play-outline",
+            CULLIGAN_IOT_DEVICES,
         )
     ]
 
@@ -126,3 +139,23 @@ class SoftenerButton(CulliganBaseEntity, ButtonEntity):
         if self.sensor_id in ["clear bypass"]:
             LOGGER.debug("Pressing clear bypass")
             await self.device.async_stop_bypass_mode() # device should be a property and set with BaseEntity
+        elif self.sensor_id in ["start timed bypass"]:
+            duration_map = getattr(self.coordinator, "timed_bypass_minutes", {})
+            if not isinstance(duration_map, dict):
+                duration_map = {}
+            try:
+                minutes = int(duration_map.get(self.device.device_serial_number, DEFAULT_TIMED_BYPASS_MINUTES))
+            except (TypeError, ValueError):
+                minutes = DEFAULT_TIMED_BYPASS_MINUTES
+            minutes = max(MIN_TIMED_BYPASS_MINUTES, min(MAX_TIMED_BYPASS_MINUTES, minutes))
+            LOGGER.debug("Starting timed bypass for %s minutes", minutes)
+            payload = self.device.set_command_payload("bypass.timed.on", True, minutes)
+            async with await self.device.culligan_api.async_request(
+                "post",
+                self.device.command_endpoint,
+                json=payload,
+            ) as resp:
+                json_resp = await resp.json()
+            if json_resp.get("success") is not True:
+                raise HomeAssistantError(f"Culligan timed bypass command failed: {json_resp}")
+            await self.coordinator.async_request_refresh()

--- a/custom_components/culligan/const.py
+++ b/custom_components/culligan/const.py
@@ -30,7 +30,13 @@ CONF_ENABLED = "enabled"
 CULLIGAN_APP_ID = "OAhRjZjfBSwKLV8MTCjscAdoyJKzjxQW"
 
 # Platforms
-PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.BINARY_SENSOR, Platform.BUTTON, Platform.NUMBER, Platform.SENSOR, Platform.SWITCH]
+
+# Smart HE timed bypass dashboard control
+DEFAULT_TIMED_BYPASS_MINUTES = 60
+MIN_TIMED_BYPASS_MINUTES = 1
+MAX_TIMED_BYPASS_MINUTES = 90
+STEP_TIMED_BYPASS_MINUTES = 1
 
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------

--- a/custom_components/culligan/entity.py
+++ b/custom_components/culligan/entity.py
@@ -2,7 +2,7 @@
 from .const import DOMAIN, LOGGER
 from .update_coordinator import CulliganUpdateCoordinator
 from ayla_iot_unofficial.device import Device, Softener
-from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
+from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTRO, CulliganIoTSoftener
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -22,10 +22,10 @@ class CulliganBaseEntity(CoordinatorEntity, Entity):
         # at a high level, we want to know if it's a culligan 'thing' or an ayla 'thing'
         self._io_culligan    = isinstance(device, CulliganIoTDevice)
 
-        # Generic CulliganIoTDevice entities are supported as read-only datapoint sensors.
+        # CulliganIoTRO entities are supported as read-only datapoint sensors.
         # Device-specific controls still belong on explicit subclasses such as CulliganIoTSoftener.
-        if self._io_culligan and not isinstance(device, CulliganIoTSoftener):
-            LOGGER.debug("Device %s is a generic CulliganIoT device", device.device_serial_number)
+        if isinstance(device, CulliganIoTRO):
+            LOGGER.debug("Device %s is a Smart RO CulliganIoT device", device.device_serial_number)
         
         # Similar, if Ayla, but not classified as 'softener' ... expect things to break
         if not self._io_culligan and not isinstance(device, Softener):

--- a/custom_components/culligan/entity.py
+++ b/custom_components/culligan/entity.py
@@ -22,19 +22,21 @@ class CulliganBaseEntity(CoordinatorEntity, Entity):
         # at a high level, we want to know if it's a culligan 'thing' or an ayla 'thing'
         self._io_culligan    = isinstance(device, CulliganIoTDevice)
 
-        # if culligan iot, but not classified as 'softener' ... expect things to break
+        # Generic CulliganIoTDevice entities are supported as read-only datapoint sensors.
+        # Device-specific controls still belong on explicit subclasses such as CulliganIoTSoftener.
         if self._io_culligan and not isinstance(device, CulliganIoTSoftener):
-            LOGGER.warning(f"Device {device.device_serial_number} is a CulliganIoT device, but was not cast as a CulliganIoTSoftener. Expect things to break!")
+            LOGGER.debug("Device %s is a generic CulliganIoT device", device.device_serial_number)
         
         # Similar, if Ayla, but not classified as 'softener' ... expect things to break
         if not self._io_culligan and not isinstance(device, Softener):
             LOGGER.warning(f"Device {device.device_serial_number} is an Ayla device, but was not cast as a Softener. Expect things to break!")
 
         # self.base_unique_id = device.name + "_" + device.device_serial_number
+        model = getattr(self.device, "device_model_number", None) or getattr(self.device, "_model", None)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.device.device_serial_number)},
             manufacturer="Culligan",
-            model=f"{self.device.name + ' ' + self.device.device_model_number}",
+            model=" ".join(part for part in [self.device.name, model] if part),
             name=self.device.name
         )
 

--- a/custom_components/culligan/manifest.json
+++ b/custom_components/culligan/manifest.json
@@ -9,6 +9,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/rewardone/homeassistant-culligan-water-softener/issues",
   "loggers": ["custom_components.culligan","culligan"],
-  "requirements": ["ayla-iot-unofficial==1.4.8","culligan==1.1.4"],
+  "requirements": ["ayla-iot-unofficial==1.4.8","culligan==1.1.6"],
   "version": "1.3.6"
 }

--- a/custom_components/culligan/number.py
+++ b/custom_components/culligan/number.py
@@ -1,0 +1,103 @@
+"""Number entities for Culligan."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import generate_entity_id
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    DEFAULT_TIMED_BYPASS_MINUTES,
+    DOMAIN,
+    LOGGER,
+    MAX_TIMED_BYPASS_MINUTES,
+    MIN_TIMED_BYPASS_MINUTES,
+    STEP_TIMED_BYPASS_MINUTES,
+)
+from .entity import CulliganBaseEntity
+from .update_coordinator import CulliganUpdateCoordinator
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_devices: AddEntitiesCallback,
+) -> None:
+    """Set up Culligan number entities from config entry."""
+    LOGGER.debug("Number async_setup_entry")
+    coordinator: CulliganUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]["coordinator"]
+    devices: Iterable[CulliganIoTDevice] = coordinator.culligan_devices.values()
+
+    if not hasattr(coordinator, "timed_bypass_minutes"):
+        coordinator.timed_bypass_minutes = {}
+    if not isinstance(coordinator.timed_bypass_minutes, dict):
+        coordinator.timed_bypass_minutes = {}
+
+    numbers = []
+    for device in devices:
+        if isinstance(device, CulliganIoTSoftener):
+            numbers.append(TimedBypassMinutesNumber(coordinator, device))
+
+    if numbers:
+        async_add_devices(numbers)
+
+    LOGGER.debug("Finished number async_add_devices")
+
+
+class TimedBypassMinutesNumber(CulliganBaseEntity, NumberEntity):
+    """Dashboard-selectable timed bypass duration for CulliganIoT softeners."""
+
+    has_entity_name = True
+    use_device_name = False
+
+    _attr_mode = NumberMode.SLIDER
+    _attr_native_min_value = MIN_TIMED_BYPASS_MINUTES
+    _attr_native_max_value = MAX_TIMED_BYPASS_MINUTES
+    _attr_native_step = STEP_TIMED_BYPASS_MINUTES
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_icon = "mdi:timer-cog-outline"
+
+    def __init__(self, coordinator: CulliganUpdateCoordinator, device: CulliganIoTSoftener) -> None:
+        """Initialize the timed bypass duration number."""
+        super().__init__(coordinator, device)
+        self._attr_description = "timed bypass duration"
+        self._attr_unique_id = f"{device.device_serial_number}_timed_bypass_minutes"
+        self.entity_id = generate_entity_id("number.{}", self._attr_unique_id, None, coordinator.hass)
+        self._attr_native_value = int(
+            coordinator.timed_bypass_minutes.get(
+                device.device_serial_number,
+                DEFAULT_TIMED_BYPASS_MINUTES,
+            )
+        )
+        self.coordinator.timed_bypass_minutes[device.device_serial_number] = self._attr_native_value
+
+    @property
+    def name(self) -> str | None:
+        """Define name as description."""
+        return self._attr_description
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique ID."""
+        return self._attr_unique_id
+
+    @property
+    def native_value(self) -> int:
+        """Return the currently selected bypass duration."""
+        duration_map = getattr(self.coordinator, "timed_bypass_minutes", {})
+        if not isinstance(duration_map, dict):
+            return self._attr_native_value
+        return int(duration_map.get(self.device.device_serial_number, self._attr_native_value))
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the timed bypass duration in minutes."""
+        minutes = round(value)
+        minutes = max(MIN_TIMED_BYPASS_MINUTES, min(MAX_TIMED_BYPASS_MINUTES, minutes))
+        self.coordinator.timed_bypass_minutes[self.device.device_serial_number] = minutes
+        self._attr_native_value = minutes
+        self.async_write_ha_state()

--- a/custom_components/culligan/sensor.py
+++ b/custom_components/culligan/sensor.py
@@ -7,7 +7,9 @@ from .update_coordinator import CulliganUpdateCoordinator
 
 from ayla_iot_unofficial.device import Device
 from collections.abc import Iterable
-from culligan.culliganiot_device import CulliganIoTDevice
+from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
+import hashlib
+import re
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
@@ -15,6 +17,7 @@ from homeassistant.const import (
     FORMAT_DATETIME,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+    EntityCategory,
     UnitOfMass,
     UnitOfTime,
     UnitOfVolume,
@@ -22,6 +25,42 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import generate_entity_id
+
+
+def _slugify_datapoint_id(datapoint_id: str) -> str:
+    """Normalize a cloud datapoint name for HA unique IDs/entity IDs."""
+    return re.sub(r"_+", "_", re.sub(r"[^a-zA-Z0-9_]+", "_", datapoint_id)).strip("_").lower()
+
+
+def _describe_datapoint(datapoint_id: str) -> str:
+    """Turn a raw cloud datapoint name into a readable sensor name."""
+    return datapoint_id.replace("_", " ")
+
+
+def _coerce_datapoint_state(value):
+    """Return a Home Assistant-compatible scalar state for a raw datapoint value."""
+    if value is None:
+        return value
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str) and len(value) <= 255:
+        return value
+    return None
+
+
+def _get_datapoint_properties(device: CulliganIoTDevice) -> dict:
+    """Return a generic CulliganIoT device's datapoint dictionary if available."""
+    properties = getattr(device, "properties", {})
+    return properties if isinstance(properties, dict) else {}
+
+
+def _datapoint_unique_suffix(datapoint_id: str) -> str:
+    """Return a stable suffix that avoids collisions from slug normalization."""
+    slug = _slugify_datapoint_id(datapoint_id) or "datapoint"
+    digest = hashlib.sha1(datapoint_id.encode("utf-8")).hexdigest()[:8]
+    return f"{slug}_{digest}"
 
 
 async def async_setup_entry(
@@ -283,6 +322,26 @@ async def async_setup_entry(
     for device in devices:
         LOGGER.debug("Working on adding sensors device: %s", device._device_serial_number)
         sensors = []
+
+        # Non-softener CulliganIoT devices, such as Smart RO, do not have a known property map yet.
+        # Expose their returned datapoints read-only so users can discover what the API provides.
+        if isinstance(device, CulliganIoTDevice) and not isinstance(device, CulliganIoTSoftener):
+            for datapoint_id in sorted(_get_datapoint_properties(device).keys()):
+                LOGGER.debug("generic CulliganIoT sensor calling async_add: %s", datapoint_id)
+                sensors += [
+                    GenericCulliganIoTSensor(
+                        coordinator,
+                        device,
+                        datapoint_id,
+                    )
+                ]
+
+            if len(sensors) > 0:
+                async_add_devices(sensors)
+
+            LOGGER.debug("Finished generic CulliganIoT sensor async_add_devices")
+            continue
+
         for sensor in softener_sensors:
             LOGGER.debug("sensor calling async_add: %s", sensor[0])
             sensors += [
@@ -304,6 +363,61 @@ async def async_setup_entry(
             async_add_devices(sensors)
 
         LOGGER.debug("Finished sensor async_add_devices")
+
+
+class GenericCulliganIoTSensor(CulliganBaseEntity, SensorEntity):
+    """Read-only sensor for generic CulliganIoT device datapoints."""
+
+    has_entity_name = True
+    use_device_name = False
+
+    def __init__(
+        self,
+        coordinator: CulliganUpdateCoordinator,
+        device: CulliganIoTDevice,
+        datapoint_id: str,
+    ) -> None:
+        """Initialize the generic CulliganIoT datapoint sensor."""
+        super().__init__(coordinator, device)
+
+        self._attr_sensor_id = datapoint_id
+        self._attr_description = _describe_datapoint(datapoint_id)
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_icon = "mdi:water-circle"
+        self._attr_unique_id = f"{device.device_serial_number}_{_datapoint_unique_suffix(datapoint_id)}"
+        self.entity_id = generate_entity_id("sensor.{}", self._attr_unique_id, None, coordinator.hass)
+
+    @property
+    def native_value(self):
+        """Return the raw datapoint value."""
+        return _coerce_datapoint_state(_get_datapoint_properties(self.device).get(self._attr_sensor_id))
+
+    @property
+    def extra_state_attributes(self):
+        """Expose metadata for raw generic datapoints."""
+        value = _get_datapoint_properties(self.device).get(self._attr_sensor_id)
+        attributes = {
+            "datapoint_id": self._attr_sensor_id,
+            "datapoint_type": type(value).__name__,
+        }
+        if _coerce_datapoint_state(value) is None and value is not None:
+            attributes["raw_value_preview"] = str(value)[:255]
+        return attributes
+
+    @property
+    def name(self) -> str | None:
+        """Define name as description. This shows in the Sensor Name column of entities."""
+        return self._attr_description
+
+    @property
+    def unique_id(self) -> str | None:
+        """Suggest the unique id of the entity. User never sees these."""
+        return self._attr_unique_id
+
+    @property
+    def icon(self) -> str | None:
+        """Define the icon."""
+        return self._attr_icon
 
 
 #class SoftenerSensor(CulliganWaterSoftenerEntity):

--- a/custom_components/culligan/sensor.py
+++ b/custom_components/culligan/sensor.py
@@ -7,7 +7,7 @@ from .update_coordinator import CulliganUpdateCoordinator
 
 from ayla_iot_unofficial.device import Device
 from collections.abc import Iterable
-from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
+from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTRO, CulliganIoTSoftener
 import hashlib
 import re
 
@@ -323,13 +323,13 @@ async def async_setup_entry(
         LOGGER.debug("Working on adding sensors device: %s", device._device_serial_number)
         sensors = []
 
-        # Non-softener CulliganIoT devices, such as Smart RO, do not have a known property map yet.
+        # Smart RO devices do not have a Home Assistant property map yet.
         # Expose their returned datapoints read-only so users can discover what the API provides.
-        if isinstance(device, CulliganIoTDevice) and not isinstance(device, CulliganIoTSoftener):
+        if isinstance(device, CulliganIoTRO):
             for datapoint_id in sorted(_get_datapoint_properties(device).keys()):
-                LOGGER.debug("generic CulliganIoT sensor calling async_add: %s", datapoint_id)
+                LOGGER.debug("Smart RO datapoint sensor calling async_add: %s", datapoint_id)
                 sensors += [
-                    GenericCulliganIoTSensor(
+                    CulliganIoTROSensor(
                         coordinator,
                         device,
                         datapoint_id,
@@ -339,7 +339,7 @@ async def async_setup_entry(
             if len(sensors) > 0:
                 async_add_devices(sensors)
 
-            LOGGER.debug("Finished generic CulliganIoT sensor async_add_devices")
+            LOGGER.debug("Finished Smart RO datapoint sensor async_add_devices")
             continue
 
         for sensor in softener_sensors:
@@ -365,8 +365,8 @@ async def async_setup_entry(
         LOGGER.debug("Finished sensor async_add_devices")
 
 
-class GenericCulliganIoTSensor(CulliganBaseEntity, SensorEntity):
-    """Read-only sensor for generic CulliganIoT device datapoints."""
+class CulliganIoTROSensor(CulliganBaseEntity, SensorEntity):
+    """Read-only sensor for Smart RO CulliganIoT device datapoints."""
 
     has_entity_name = True
     use_device_name = False
@@ -374,10 +374,10 @@ class GenericCulliganIoTSensor(CulliganBaseEntity, SensorEntity):
     def __init__(
         self,
         coordinator: CulliganUpdateCoordinator,
-        device: CulliganIoTDevice,
+        device: CulliganIoTRO,
         datapoint_id: str,
     ) -> None:
-        """Initialize the generic CulliganIoT datapoint sensor."""
+        """Initialize the Smart RO datapoint sensor."""
         super().__init__(coordinator, device)
 
         self._attr_sensor_id = datapoint_id
@@ -394,7 +394,7 @@ class GenericCulliganIoTSensor(CulliganBaseEntity, SensorEntity):
 
     @property
     def extra_state_attributes(self):
-        """Expose metadata for raw generic datapoints."""
+        """Expose metadata for raw Smart RO datapoints."""
         value = _get_datapoint_properties(self.device).get(self._attr_sensor_id)
         attributes = {
             "datapoint_id": self._attr_sensor_id,

--- a/custom_components/culligan/switch.py
+++ b/custom_components/culligan/switch.py
@@ -20,8 +20,8 @@ from ayla_iot_unofficial.device import Device, Softener
 from collections.abc import Iterable
 from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
 
-AYLA_DEVICES = [Device, Softener]
-CULLIGAN_IOT_DEVICES = [CulliganIoTDevice, CulliganIoTSoftener]
+AYLA_DEVICES = [Softener]
+CULLIGAN_IOT_DEVICES = [CulliganIoTSoftener]
 ALL_DEVICES = AYLA_DEVICES + CULLIGAN_IOT_DEVICES
 
 async def async_setup_entry(

--- a/custom_components/culligan/update_coordinator.py
+++ b/custom_components/culligan/update_coordinator.py
@@ -68,7 +68,7 @@ class CulliganUpdateCoordinator(DataUpdateCoordinator[bool]):
         return dsn in self._online_dsns
 
     @staticmethod
-    async def _async_update_softener(softener: Softener | CulliganIoTSoftener) -> None:
+    async def _async_update_softener(softener: Softener | CulliganIoTDevice | CulliganIoTSoftener) -> None:
         """Asynchronously update the data for a single device."""
         dsn = softener.device_serial_number
         LOGGER.debug(
@@ -103,8 +103,8 @@ class CulliganUpdateCoordinator(DataUpdateCoordinator[bool]):
                     "batch_datapoint send failure, properties will not be accurate"
                 )
 
-        if isinstance(softener, CulliganIoTSoftener):
-            LOGGER.debug("updating culliganiot softener")
+        if isinstance(softener, CulliganIoTDevice):
+            LOGGER.debug("updating culliganiot device")
             async with timeout(API_TIMEOUT):
                 try:
                     LOGGER.debug("starting async_update")
@@ -192,7 +192,7 @@ class CulliganUpdateCoordinator(DataUpdateCoordinator[bool]):
 
         # self.culligan_devices is now only supported_devices as of 1.3.1, need another check here to not update 'online but not supported' devices
         temp = {}
-        SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener]
+        SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener, CulliganIoTDevice]
         for device in all_online_devices:
             dsn = ""
             # check DSN for Ayla, serialNumber for CulliganIoT

--- a/custom_components/culligan/update_coordinator.py
+++ b/custom_components/culligan/update_coordinator.py
@@ -9,7 +9,7 @@ from ayla_iot_unofficial.device import Device, Softener
 from ayla_iot_unofficial import AylaAuthError, AylaNotAuthedError, AylaAuthExpiringError
 from culligan import CulliganApi
 from culligan.exc import CulliganAuthError, CulliganNotAuthedError, CulliganAuthExpiringError
-from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTSoftener
+from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTRO, CulliganIoTSoftener
 
 from datetime import datetime, timedelta
 
@@ -27,7 +27,7 @@ class CulliganUpdateCoordinator(DataUpdateCoordinator[bool]):
         hass: HomeAssistant,
         config_entry: ConfigEntry,
         culligan_api: CulliganApi,
-        culligan_devices: list[Softener] | list[Device] | list[CulliganIoTDevice] | list[CulliganIoTSoftener],
+        culligan_devices: list[Softener] | list[Device] | list[CulliganIoTRO] | list[CulliganIoTSoftener],
     ) -> None:
         """Set up the CulliganUpdateCoordinator class."""
         LOGGER.debug("coordinator init")
@@ -68,7 +68,7 @@ class CulliganUpdateCoordinator(DataUpdateCoordinator[bool]):
         return dsn in self._online_dsns
 
     @staticmethod
-    async def _async_update_softener(softener: Softener | CulliganIoTDevice | CulliganIoTSoftener) -> None:
+    async def _async_update_softener(softener: Softener | CulliganIoTRO | CulliganIoTSoftener) -> None:
         """Asynchronously update the data for a single device."""
         dsn = softener.device_serial_number
         LOGGER.debug(
@@ -192,7 +192,7 @@ class CulliganUpdateCoordinator(DataUpdateCoordinator[bool]):
 
         # self.culligan_devices is now only supported_devices as of 1.3.1, need another check here to not update 'online but not supported' devices
         temp = {}
-        SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener, CulliganIoTDevice]
+        SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener, CulliganIoTRO]
         for device in all_online_devices:
             dsn = ""
             # check DSN for Ayla, serialNumber for CulliganIoT

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_default_fixture_loop_scope=function

--- a/tests/test_smart_ro_library_boundary.py
+++ b/tests/test_smart_ro_library_boundary.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text()
+
+
+def test_setup_supports_explicit_culligan_iot_ro_not_generic_device():
+    init_py = _read("custom_components/culligan/__init__.py")
+
+    assert "CulliganIoTRO" in init_py
+    assert "SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener, CulliganIoTRO]" in init_py
+    assert "SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener, CulliganIoTDevice]" not in init_py
+
+
+def test_ro_datapoint_sensors_are_bound_to_explicit_ro_class():
+    sensor_py = _read("custom_components/culligan/sensor.py")
+
+    assert "CulliganIoTRO" in sensor_py
+    assert "class CulliganIoTROSensor" in sensor_py
+    assert "if isinstance(device, CulliganIoTRO):" in sensor_py
+    assert "GenericCulliganIoTSensor" not in sensor_py
+    assert "isinstance(device, CulliganIoTDevice) and not isinstance(device, CulliganIoTSoftener)" not in sensor_py
+
+
+def test_update_coordinator_tracks_ro_as_supported_without_generic_iot_support():
+    coordinator_py = _read("custom_components/culligan/update_coordinator.py")
+
+    assert "CulliganIoTRO" in coordinator_py
+    assert "SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener, CulliganIoTRO]" in coordinator_py
+    assert "SUPPORTED_DEVICE_CLASSES = [Softener, CulliganIoTSoftener, CulliganIoTDevice]" not in coordinator_py
+
+
+def test_manifest_pins_culligan_library_version_with_ro_class():
+    manifest_json = _read("custom_components/culligan/manifest.json")
+
+    assert '"culligan==1.1.6"' in manifest_json


### PR DESCRIPTION
## Summary
- Supports explicit `CulliganIoTRO` devices from the underlying `culligan` library instead of treating generic `CulliganIoTDevice` as supported.
- Adds diagnostic, read-only Smart RO datapoint sensors as a discovery path for real RO payloads.
- Keeps existing Smart HE / softener-specific sensors and controls unchanged.
- Explicitly keeps RO devices sensor-only: no buttons, switches, numbers, binary sensors, or cloud commands.
- Adds Smart HE timed bypass dashboard controls:
  - `number.*_timed_bypass_minutes` slider, 1–90 minutes
  - `button.*_start_timed_bypass`
  - sends the correct Culligan IoT command `bypass.timed.on`

## Dependency
This PR now depends on the library PR that adds `CulliganIoTRO`:
- https://github.com/rewardone/Culligan/pull/36

The manifest pins the future package version as `culligan==1.1.6`; this PR should remain draft until that library change is merged and released.

## Why
Accounts can include Smart RO / reverse-osmosis CulliganIoT devices. The integration can discover them, but it previously filtered unsupported devices before Home Assistant could expose anything.

Per owner feedback, Smart RO support now belongs at the library boundary first: the library identifies RO devices as `CulliganIoTRO`, and this integration only supports that explicit class. This avoids guessing that arbitrary generic IoT devices are safe to expose.

For Smart HE, the mobile app supports timed bypass. The underlying library exposes a timed bypass payload builder, but its async timed-bypass helper sends the permanent-bypass command in v1.1.4, so this integration sends the correct `bypass.timed.on` payload directly.

## Notes
Smart RO support is intentionally diagnostic/discovery-first. It does not add RO controls and does not try to guess polished device classes or units before seeing real Smart RO datapoints.

Smart RO datapoint sensors are marked diagnostic and are hardened for missing/changing datapoints, non-scalar values, long strings, and datapoint-name collisions.

Timed bypass duration is stored per Smart HE device serial number and is clamped again at button press before any cloud command is sent.

## Test plan
- [x] `python3 -m pytest tests/test_smart_ro_library_boundary.py -q`
- [x] `python3 -m compileall -q custom_components/culligan`
- [x] `git diff --check upstream/main`
- [x] Added-line static security scan: 0 findings
- [x] Targeted smoke checks:
  - Smart RO support is bound to explicit `CulliganIoTRO`, not generic `CulliganIoTDevice`
  - Smart RO devices do not get softener buttons
  - Smart RO devices do not get softener switches
  - Smart RO devices do not get softener binary sensors
  - Smart RO devices do not get softener number entities
  - Smart RO datapoint sensors are diagnostic/read-only and use stable hashed IDs
  - timed bypass button uses `bypass.timed.on`, not `bypass.permanent.on`
  - timed bypass duration is per-device and clamped 1–90 minutes
- [x] Independent high-scrutiny code review passed after fixing two blockers: global duration state and aiohttp request-context handling
- [x] Live HA install/restart verified Smart RO still sensor-only and Smart HE timed bypass entities appear
- [ ] Press the timed bypass button against a real Smart HE device and confirm the cloud/app reports the selected timed bypass duration.
- [ ] Promote known RO datapoints to typed sensors once payloads are confirmed.
