### PR TITLE
fix: auto re-login on invalidated token

### DIFF
--- a/custom_components/culligan/update_coordinator.py
+++ b/custom_components/culligan/update_coordinator.py
@@ -12,11 +12,43 @@ from culligan.exc import CulliganAuthError, CulliganNotAuthedError, CulliganAuth
 from culligan.culliganiot_device import CulliganIoTDevice, CulliganIoTRO, CulliganIoTSoftener
 
 from datetime import datetime, timedelta
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+
+async def async_fetch_registry_devices(culligan_api: CulliganApi) -> list[Any]:
+    """Fetch CulliganIoT device registry, re-signing in once if the server rejects the token.
+
+    The server can invalidate a token before its local expiry (e.g. mobile app sign-in),
+    in which case the proactive expiry-clock refresh never fires. Credentials are kept on
+    the CulliganApi instance, so a full re-sign-in recovers without user action.
+    """
+    try:
+        registry: Any = await culligan_api.async_get_device_registry()
+        return registry["data"]["devices"]
+    except (CulliganAuthError, CulliganNotAuthedError, CulliganAuthExpiringError):
+        LOGGER.info("Culligan token rejected by server, re-authenticating")
+        try:
+            await culligan_api.async_sign_in()
+            # devices hold a reference to the existing AylaApi object: refresh its tokens in place
+            if culligan_api.Ayla:
+                culligan_api.Ayla._set_credentials(
+                    200,
+                    {
+                        "access_token": culligan_api._ayla_access_token,
+                        "refresh_token": culligan_api._ayla_refresh_token,
+                        "expires_in": culligan_api._ayla_expiration_raw,
+                    },
+                )
+            registry = await culligan_api.async_get_device_registry()
+            return registry["data"]["devices"]
+        except (CulliganAuthError, CulliganNotAuthedError) as err:
+            # credentials genuinely invalid (password changed) — needs user action
+            raise ConfigEntryAuthFailed from err
 
 
 class CulliganUpdateCoordinator(DataUpdateCoordinator[bool]):
@@ -187,8 +219,8 @@ class CulliganUpdateCoordinator(DataUpdateCoordinator[bool]):
                 )
                 raise UpdateFailed(err) from err
 
-        # Add online devices from Culligan
-        all_online_devices += (await self.culligan_api.async_get_device_registry())["data"]["devices"]
+        # Add online devices from Culligan (re-signs in automatically on INVALID_TOKEN)
+        all_online_devices += await async_fetch_registry_devices(self.culligan_api)
 
         # self.culligan_devices is now only supported_devices as of 1.3.1, need another check here to not update 'online but not supported' devices
         temp = {}

--- a/tests/test_auth_recovery.py
+++ b/tests/test_auth_recovery.py
@@ -1,0 +1,58 @@
+"""Tests for automatic re-authentication (issue #15)."""
+import asyncio
+
+import pytest
+from culligan.exc import CulliganAuthError
+
+from custom_components.culligan.update_coordinator import async_fetch_registry_devices
+from homeassistant.exceptions import ConfigEntryAuthFailed
+
+DEVICES = [{"serialNumber": "ABC123"}]
+
+
+class FakeCulliganApi:
+    """Minimal CulliganApi double for registry/auth behavior."""
+
+    Ayla = None
+    _ayla_access_token = "at"
+    _ayla_refresh_token = "rt"
+    _ayla_expiration_raw = 3600
+
+    def __init__(self, registry_errors: int = 0, sign_in_error: bool = False):
+        self._registry_errors = registry_errors
+        self._sign_in_error = sign_in_error
+        self.sign_in_calls = 0
+        self.registry_calls = 0
+
+    async def async_get_device_registry(self):
+        self.registry_calls += 1
+        if self._registry_errors > 0:
+            self._registry_errors -= 1
+            raise CulliganAuthError({"error": {"message": "INVALID_TOKEN"}})
+        return {"data": {"devices": DEVICES}}
+
+    async def async_sign_in(self):
+        self.sign_in_calls += 1
+        if self._sign_in_error:
+            raise CulliganAuthError({"error": {"message": "BAD_CREDENTIALS"}})
+
+
+def test_nominal_fetch_does_not_sign_in():
+    api = FakeCulliganApi()
+    devices = asyncio.run(async_fetch_registry_devices(api))
+    assert devices == DEVICES
+    assert api.sign_in_calls == 0
+
+
+def test_invalid_token_triggers_resign_in_and_retry():
+    api = FakeCulliganApi(registry_errors=1)
+    devices = asyncio.run(async_fetch_registry_devices(api))
+    assert devices == DEVICES
+    assert api.sign_in_calls == 1
+    assert api.registry_calls == 2
+
+
+def test_bad_credentials_raise_config_entry_auth_failed():
+    api = FakeCulliganApi(registry_errors=1, sign_in_error=True)
+    with pytest.raises(ConfigEntryAuthFailed):
+        asyncio.run(async_fetch_registry_devices(api))


### PR DESCRIPTION
## Summary

Fixes #15.

The Culligan server can invalidate a token before its local expiry (e.g. after a sign-in from the mobile app). When that happens, the proactive expiry-clock refresh never fires and every update cycle fails with `INVALID_TOKEN` until the integration is removed and re-added.

This PR makes the device registry fetch recover automatically:

- New `async_fetch_registry_devices` helper in `update_coordinator.py`: on `CulliganAuthError` / `CulliganNotAuthedError` / `CulliganAuthExpiringError`, it re-signs in once with the stored credentials, refreshes the Ayla tokens in place (devices hold a reference to the existing `AylaApi` object), and retries the fetch.
- `ConfigEntryAuthFailed` is only raised when the re-sign-in itself fails (credentials genuinely invalid, e.g. password changed), so Home Assistant prompts for re-auth only when user action is actually needed.

## Test plan

`tests/test_auth_recovery.py` covers the three paths:
- nominal fetch does not trigger a sign-in
- `INVALID_TOKEN` triggers exactly one re-sign-in and a successful retry
- bad credentials raise `ConfigEntryAuthFailed`

All 3 tests pass locally with pytest.

## Images

before/after on wifi strength
<img width="1936" height="1052" alt="image" src="https://github.com/user-attachments/assets/086b15b4-ccee-44e6-b3b5-c939b2a73630" />

before/after on water consumption
<img width="974" height="504" alt="image" src="https://github.com/user-attachments/assets/5208913a-66fa-46cb-b70e-e26afbb390d9" />


